### PR TITLE
Improve; RMI prints more descriptive error message when the connection fails 

### DIFF
--- a/fanuc_libs/rmi/src/rmi.cpp
+++ b/fanuc_libs/rmi/src/rmi.cpp
@@ -143,7 +143,8 @@ struct RMIConnection::PConnectionImpl
     std::scoped_lock lock(mutex_);
     if (!conn.connect(server_address))
     {
-      throw std::runtime_error("Failed to create TCP connection at: " + robot_ip_address);
+      const int err = errno;  // Capture errno before any other operations
+      throw std::runtime_error("Failed to create TCP connection to " + robot_ip_address + ":" + std::to_string(robot_port) + ". Reason: " + std::strerror(err));
     }
     conn.set_non_blocking(true);
   }


### PR DESCRIPTION
I know external contribution is not accepted but just opening this for sharing purpose.

Aims to close/mitigate https://github.com/FANUC-CORPORATION/fanuc_driver/issues/31

Used this patch on the same environment as https://github.com/FANUC-CORPORATION/fanuc_driver/issues/30#issue-4118323407. Seeing port number, the reason (time out) helps the dev to understand what the roadblocks are.
```
# ./build/fanuc_libs/examples/rmi_connection_example 
RMIConnection created for robot IP: 192.168.188.106
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to create TCP connection to 192.168.188.106:16001. Reason: Connection timed out
Aborted (core dumped)
```
