### PR TITLE
Release v1.4.0

### DIFF
--- a/fanuc_controllers/package.xml
+++ b/fanuc_controllers/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_controllers</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>ROS2 controllers for FANUC robots</description>
   <maintainer email="fanuc-ros-maintainer@fanuc.co.jp">FANUC CORPORATION</maintainer>
   <license>Apache-2.0</license>

--- a/fanuc_controllers/src/fanuc_gpio_controller.cpp
+++ b/fanuc_controllers/src/fanuc_gpio_controller.cpp
@@ -65,7 +65,8 @@ void GetBoolIO(const std::shared_ptr<fanuc_msgs::srv::GetBoolIO::Request>& reque
                const std::shared_ptr<fanuc_msgs::srv::GetBoolIO::Response>& response)
 {
   std::vector supported_types = { fanuc_msgs::msg::IOType::DI, fanuc_msgs::msg::IOType::RI, fanuc_msgs::msg::IOType::DO,
-                                  fanuc_msgs::msg::IOType::RO, fanuc_msgs::msg::IOType::F };
+                                  fanuc_msgs::msg::IOType::RO, fanuc_msgs::msg::IOType::F,  fanuc_msgs::msg::IOType::UO,
+                                  fanuc_msgs::msg::IOType::UI };
   if (std::find(supported_types.begin(), supported_types.end(), request->io_type.type) == supported_types.end())
   {
     response->result = 1;

--- a/fanuc_examples/fanuc_dual_arm_example/package.xml
+++ b/fanuc_examples/fanuc_dual_arm_example/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_dual_arm_example</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>
      An example package to control two FANUC robots with MoveIt2.
   </description>

--- a/fanuc_forward_command/package.xml
+++ b/fanuc_forward_command/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_forward_command</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>FANUC robot forward command controller configuration and sine wave generator</description>
   <maintainer email="fanuc-ros-maintainer@fanuc.co.jp">FANUC CORPORATION</maintainer>
   <license>Apache-2.0</license>

--- a/fanuc_hardware_interface/package.xml
+++ b/fanuc_hardware_interface/package.xml
@@ -7,7 +7,7 @@
   -->
 <package format="3">
   <name>fanuc_hardware_interface</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>
     ROS 2 control streaming driver for FANUC robots.
   </description>

--- a/fanuc_libs/fanuc_client/src/fanuc_client.cpp
+++ b/fanuc_libs/fanuc_client/src/fanuc_client.cpp
@@ -494,7 +494,11 @@ void FanucClient::startRMI()
   try
   {
     rmi_connection_->reset(std::nullopt);
-    rmi_connection_->initializeRemoteMotion(std::nullopt);
+    rmi_connection_->initializeRemoteMotion(std::nullopt,  // timeout
+                                            1,             // groupmask
+                                            std::nullopt,  // rtsa
+                                            std::nullopt   // pltzmode
+    );
   }
   catch (const std::runtime_error&)
   {
@@ -502,7 +506,11 @@ void FanucClient::startRMI()
     rmi_connection_->abort(std::nullopt);
     rmi_connection_->reset(std::nullopt);
     rmi_connection_->getStatus(std::nullopt);
-    rmi_connection_->initializeRemoteMotion(std::nullopt);
+    rmi_connection_->initializeRemoteMotion(std::nullopt,  // timeout
+                                            1,             // groupmask
+                                            std::nullopt,  // rtsa
+                                            std::nullopt   // pltzmode
+    );
   }
   rmi_running_ = true;
 }

--- a/fanuc_libs/fanuc_client/test/fanuc_client_test.cpp
+++ b/fanuc_libs/fanuc_client/test/fanuc_client_test.cpp
@@ -99,6 +99,10 @@ public:
   MOCK_METHOD(rmi::ConnectROS2Packet::Response, connect, (std::optional<double> timeout), (override));
   MOCK_METHOD(rmi::DisconnectPacket::Response, disconnect, (std::optional<double> timeout), (override));
   MOCK_METHOD(rmi::InitializePacket::Response, initializeRemoteMotion, (std::optional<double> timeout), (override));
+  MOCK_METHOD(rmi::InitializePacket::Response, initializeRemoteMotion,
+              (std::optional<double> timeout, const std::optional<uint8_t> groupmask,
+               const std::optional<std::string>& rtsa, const std::optional<std::string>& pltzmode),
+              (override));
   MOCK_METHOD(rmi::ProgramCallPacket::Response, programCall,
               (const std::string& program_name, std::optional<double> timeout), (override));
   MOCK_METHOD(rmi::ProgramCallPacket::Request, programCallNonBlocking, (const std::string& program_name), (override));

--- a/fanuc_libs/package.xml
+++ b/fanuc_libs/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_libs</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>
     This package provides essential C++ libraries for interfacing with FANUC
     robotic systems.

--- a/fanuc_libs/rmi/include/rmi/rmi.hpp
+++ b/fanuc_libs/rmi/include/rmi/rmi.hpp
@@ -24,6 +24,10 @@ public:
   virtual DisconnectPacket::Response disconnect(std::optional<double> timeout) = 0;
 
   virtual InitializePacket::Response initializeRemoteMotion(std::optional<double> timeout) = 0;
+  virtual InitializePacket::Response initializeRemoteMotion(std::optional<double> timeout,
+                                                            const std::optional<uint8_t> groupmask,
+                                                            const std::optional<std::string>& rtsa,
+                                                            const std::optional<std::string>& pltzmode) = 0;
 
   virtual ProgramCallPacket::Response programCall(const std::string& program_name, std::optional<double> timeout) = 0;
 
@@ -120,6 +124,10 @@ public:
   DisconnectPacket::Response disconnect(std::optional<double> timeout) override;
 
   InitializePacket::Response initializeRemoteMotion(std::optional<double> timeout) override;
+  InitializePacket::Response initializeRemoteMotion(std::optional<double> timeout,
+                                                    const std::optional<uint8_t> groupmask,
+                                                    const std::optional<std::string>& rtsa,
+                                                    const std::optional<std::string>& pltzmode) override;
 
   ProgramCallPacket::Response programCall(const std::string& program_name, std::optional<double> timeout) override;
 

--- a/fanuc_libs/rmi/src/rmi.cpp
+++ b/fanuc_libs/rmi/src/rmi.cpp
@@ -316,11 +316,28 @@ DisconnectPacket::Response RMIConnection::disconnect(const std::optional<double>
 
 InitializePacket::Response RMIConnection::initializeRemoteMotion(const std::optional<double> timeout)
 {
+  return initializeRemoteMotion(timeout, std::nullopt, std::nullopt, std::nullopt);
+}
+
+InitializePacket::Response RMIConnection::initializeRemoteMotion(const std::optional<double> timeout,
+                                                                 const std::optional<uint8_t> groupmask,
+                                                                 const std::optional<std::string>& rtsa,
+                                                                 const std::optional<std::string>& pltzmode)
+{
   {
     std::scoped_lock lock(mutex_);
     sequence_number_ = 1;  // Reset sequence number for a new session
   }
-  connection_impl_->write(InitializePacket::Request());
+
+  const auto packet = [&]() {
+    auto request = InitializePacket::Request();
+    request.GroupMask = groupmask;
+    request.RTSA = rtsa;
+    request.PLTZMODE = pltzmode;
+    return request;
+  }();
+  connection_impl_->write(packet);
+
   return getResponsePacket<InitializePacket::Response>(timeout, "Failed to initialize RMI. ", std::nullopt);
 }
 

--- a/fanuc_moveit_config/launch/fanuc_moveit.launch.py
+++ b/fanuc_moveit_config/launch/fanuc_moveit.launch.py
@@ -85,6 +85,7 @@ def launch_setup(context, *args, **kwargs):
         "gpio_configuration": PathJoinSubstitution(
             [FindPackageShare(gpio_config_package), gpio_config_path]
         ),
+        "motion_control": motion_control.perform(context),
     }
 
     urdf_full_path = os.path.join(

--- a/fanuc_moveit_config/launch/fanuc_moveit_template.launch.py
+++ b/fanuc_moveit_config/launch/fanuc_moveit_template.launch.py
@@ -89,6 +89,7 @@ def launch_setup(context, *args, **kwargs):
         "gpio_configuration": PathJoinSubstitution(
             [FindPackageShare(gpio_config_package), gpio_config_path]
         ),
+        "motion_control": motion_control.perform(context),
     }
 
     urdf_full_path = os.path.join(

--- a/fanuc_moveit_config/package.xml
+++ b/fanuc_moveit_config/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_moveit_config</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>
      An example package with MoveIt2 configurations for FANUC robots.
   </description>

--- a/fanuc_msgs/package.xml
+++ b/fanuc_msgs/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>fanuc_msgs</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>Messages for interacting with FANUC Robots.</description>
   <maintainer email="fanuc-ros-maintainer@fanuc.co.jp">FANUC CORPORATION</maintainer>
   <license>Apache-2.0</license>

--- a/slider_publisher/package.xml
+++ b/slider_publisher/package.xml
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <package format="3">
   <name>slider_publisher</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>Slider GUI publisher for ROS2</description>
   <maintainer email="fanuc-ros-maintainer@fanuc.co.jp">FANUC CORPORATION</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
<!--
Pre-commit hooks must be run before merging a PR.

To run after committing use:
    pre-commit -a
For staged files use:
    pre-commit
Or you can automatically run this on commit after calling:
    pre-commit install

See https://pre-commit.com for installation steps and other details.
-->

# New Feature
* Added support for reading UI/IO to the `/get_bool_io` service.
# Enhancement
* Added support for operating the robot in group 1 of the multi-group control system.
# Bugfix
* Fixed an issue that the `motion_control` launch argument is sometimes ignored.
# Others
* Added GitHub issue templates.